### PR TITLE
fix: invalid year range error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "spdx",
  "tabled",
  "tempfile",
+ "thiserror",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ colored = "2.1.0"
 inquire = "0.6.2"
 spdx = "0.10.3"
 handlebars = "5.1.0"
+thiserror = "1.0.56"
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,8 +93,7 @@ pub struct Config {
     ///
     /// This field is used to define the copyright duration when applying license headers.
     /// When providing a range, it signifies the inclusive span of years.
-    // TODO: impl parser in crate `parser` mod
-    #[arg(long, value_name = "YYYY | YYYY-YYYY | YYYY-present")]
+    #[arg(long, value_name = "YYYY | YYYY-YYYY | YYYY-present", value_parser = crate::parser::parse_license_year)]
     pub year: Option<LicenseYear>,
 
     /// A list of glob patterns to exclude from the licensing process.
@@ -203,5 +202,30 @@ impl Config {
         }
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_config_invalid_license_year() {
+        let config = serde_json::from_value::<Config>(json!({
+            "year": 20033,
+        }));
+        assert!(config.is_err());
+
+        let config = serde_json::from_value::<Config>(json!({
+            "year": null,
+        }));
+        assert!(config.is_ok());
+
+        let config = serde_json::from_value::<Config>(json!({
+            "year": "2025-2024",
+        }));
+        assert!(config.is_err());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,11 +5,18 @@ use std::str::FromStr;
 
 use anyhow::Result;
 
-use crate::schema::LicenseId;
+use crate::schema::{LicenseId, LicenseYear, LicenseYearError};
 
 pub fn parse_license_id(input: &str) -> Result<LicenseId> {
     // We trim leading and trailing `"` in case an user provides a single license ID
     // as `--type "MIT"`, whereas it should be provided as `--type MIT`.
     let typ = input.trim_matches('"');
     LicenseId::from_str(input)
+}
+
+pub fn parse_license_year(input: &str) -> Result<LicenseYear, LicenseYearError> {
+    // Trim leading and trailing `"` in case an user provides a single license year
+    // as `--year "2003"`, where it should be provided as `--type 2003`.
+    let input = input.trim_matches('"');
+    LicenseYear::from_str(input)
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #22 <!-- Issue # here -->

## 📑 Description

Previously, attempts to utilize commands with the `--year` flag or parsing the `.licensarc` configuration file would result in errors due to mishandling of the `YYYY-present` format for license years.

**Changes Made:**
- Resolved the issue where errors occurred during the execution of CLI commands utilizing the `--year` flag.
- Fixed parsing errors encountered when reading license year periods from the `.licensarc` configuration file.
- Added custom `LicenseYearError` enum

**Fixes:**
- CLI commands now properly handle the `--year` flag, ensuring correct (de)serialization and parsing of license years.
- Parsing of license year periods from the `.licensarc` configuration file has been rectified, preventing errors and ensuring accurate interpretation of `YYYY-present` format.


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
