### PR TITLE
fix(scripts): invalid bash script archive name

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,11 +6,11 @@ function write_log {
     message=$2
 
     case $level in
-        "info")   foreground_color="\e[34m" ;;
-        "success") foreground_color="\e[32m" ;;
-        "warn")    foreground_color="\e[33m" ;;
-        "error")   foreground_color="\e[31m" ;;
-        *)         foreground_color="\e[97m" ;;  # Default to white
+    "info") foreground_color="\e[34m" ;;
+    "success") foreground_color="\e[32m" ;;
+    "warn") foreground_color="\e[33m" ;;
+    "error") foreground_color="\e[31m" ;;
+    *) foreground_color="\e[97m" ;; # Default to white
     esac
 
     timestamp=$(date +"%Y-%m-%d %H:%M:%S")
@@ -29,16 +29,16 @@ architecture=$(uname -m)
 
 # Adjust asset_name_unpacked based on architecture
 case "$architecture" in
-    "x86_64")
-        asset_name_unpacked="${bin_name}-${release_tag}-x86_64-linux"
-        ;;
-    "aarch64")
-        asset_name_unpacked="${bin_name}-${release_tag}-aarch64-linux"
-        ;;
-    *)
-        write_log "error" "Unsupported architecture: $architecture"
-        exit 1
-        ;;
+"x86_64")
+    asset_name_unpacked="${bin_name}-${release_tag}-x86_64-linux"
+    ;;
+"aarch64")
+    asset_name_unpacked="${bin_name}-${release_tag}-aarch64-linux"
+    ;;
+*)
+    write_log "error" "Unsupported architecture: $architecture"
+    exit 1
+    ;;
 esac
 
 asset_name_tar="${asset_name_unpacked}.tar.xz"
@@ -73,13 +73,9 @@ write_log "success" "Successfully unpacked $asset_name_tar"
 write_log "info" "Installing..."
 destination_path="/usr/local/bin"
 
-# HACK: the extracted folder in v0.1.0 is capitalized
-# TODO: Remove for new releases (including minor releases)  
-asset_name_unpacked="Licensa-${release_tag}-${architecture}-linux"
-source_folder="$downloads_folder/$asset_name_unpacked"
-
 # Move unpacked source to destination
 # TODO: Ask if should override, if path exists
+source_folder="$downloads_folder/$asset_name_unpacked"
 sudo cp -r "$source_folder"/* "$destination_path"
 
 # Remove downloaded tar.gz


### PR DESCRIPTION
The initial release mistakenly used a capitalized archive name. Consequently, in the Linux install script, we resorted to using the capitalized archive name temporarily when moving the unpacked directory to the usr/local/bin directory.

This PR removes the temporary workaround since it's no longer necessary as of v0.1.1.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
