### PR TITLE
fix: remove unneeded serde conversion in init command

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -47,9 +47,7 @@ pub fn run(args: &InitArgs) -> Result<()> {
         let _ = config.owner.insert(owner);
     }
 
-    let workspace_config = serde_json::to_value(config)?;
-    let workspace_config: Config = serde_json::from_value(workspace_config)?;
-    save_workspace_config(&workspace_root, workspace_config)?;
+    save_workspace_config(&workspace_root, config)?;
     save_workspace_ignore(workspace_root)?;
 
     println!("Successfully initialized Licensa workspace");


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->
This PR removes *serde* calls in the `init` command. We no longer need to first serialize the config to JSON and then convert it back to a `Config` struct.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
