### PR TITLE
fix(cli): invalid type error when missing exclude flag

### DIFF
--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -34,7 +34,7 @@ pub fn run(args: &mut VerifyArgs) -> anyhow::Result<()> {
     // ========================================================
 
     let mut walk_builder = WalkBuilder::new(&workspace_root);
-    walk_builder.exclude(config.exclude.clone())?;
+    walk_builder.exclude(Some(config.exclude.clone()))?;
 
     let mut walker = walk_builder.build()?;
     walker

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,9 @@ pub struct Config {
     #[cfg(not(doctest))]
     #[arg(long, verbatim_doc_comment)]
     #[arg(value_name = "GLOB[,...]", value_delimiter = ' ', num_args = 1..)]
-    pub exclude: Option<Vec<String>>,
+    #[arg(default_values_t = Vec::<String>::new())]
+    #[serde(default = "Vec::new")]
+    pub exclude: Vec<String>,
 }
 
 impl Config {
@@ -108,13 +110,14 @@ impl Config {
             license: empty.license().map(|s| s.into()),
             owner: empty.holder().map(|s| s.to_owned()),
             year: empty.year().map(|s| s.to_owned()),
-            exclude: Some(empty.exclude().to_vec()),
+            exclude: empty.exclude().to_vec(),
         }
     }
 
     pub fn update(&mut self, source: Config) {
-        if let Some(exclude) = source.exclude.as_deref() {
-            self.exclude = Some(exclude.to_owned())
+        if !source.exclude.is_empty() {
+            let mut patterns = source.exclude;
+            self.exclude.append(&mut patterns);
         }
         if let Some(holder) = source.owner.as_deref() {
             self.owner = Some(holder.to_owned())
@@ -128,7 +131,7 @@ impl Config {
     }
 
     pub fn exclude(&self) -> &[String] {
-        self.exclude.as_ref().map(|v| v.as_ref()).unwrap_or(&[])
+        self.exclude.as_ref()
     }
 
     pub fn holder(&self) -> Option<&str> {


### PR DESCRIPTION
This PR resolves an error caused by parsing workspace configuration and merging it with user-provided CLI arguments/flags. Users had to explicitly add the `exclude` flag or provide it's value in the licensarc.json file, which is ultimately undesirable.

Now, users are not required to explicitly provide this flag nor add it to the licensarc.json file.

Closes #66

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
