### PR TITLE
chore: remove needless lifetime annotations

### DIFF
--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -62,7 +62,6 @@ where
 /// the provided directory path or if there's an issue reading the file content.
 pub fn resolve_workspace_config<T>(workspace_root: impl AsRef<Path>) -> Result<T>
 where
-    T: ?Sized,
     for<'de> T: Deserialize<'de>,
 {
     let workspace_root = workspace_root.as_ref();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -246,7 +246,7 @@ impl<'de> Deserialize<'de> for LicenseYear {
     {
         struct LicenseYearVisitor;
 
-        impl<'de> de::Visitor<'de> for LicenseYearVisitor {
+        impl de::Visitor<'_> for LicenseYearVisitor {
             type Value = LicenseYear;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/template/header.rs
+++ b/src/template/header.rs
@@ -126,7 +126,7 @@ pub struct HeaderDefinition<'a> {
     pub header_prefix: HeaderPrefix<'a>,
 }
 
-impl<'a> HeaderDefinition<'a> {
+impl HeaderDefinition<'_> {
     /// Checks if the given extension is contained in the list of file extensions.
     pub fn contains_extension<E: AsRef<str>>(&self, extension: Option<E>) -> bool {
         extension

--- a/src/workspace/ops.rs
+++ b/src/workspace/ops.rs
@@ -46,7 +46,6 @@ use std::path::{Path, PathBuf};
 /// the provided directory path or if there's an issue reading the file content.
 pub fn read_config_into<T, P, F>(workspace_root: P, file_name: F) -> WorkspaceResult<T>
 where
-    T: ?Sized,
     for<'de> T: Deserialize<'de>,
     P: AsRef<Path>,
     F: AsRef<str>,
@@ -117,7 +116,6 @@ where
 /// * `Err(WorkspaceError)` if there's an error reading or parsing the file content.
 pub fn resolve_config_into<T, P, F>(workspace_root: P, file_name: F) -> WorkspaceResult<Option<T>>
 where
-    T: ?Sized,
     for<'de> T: Deserialize<'de>,
     P: AsRef<Path>,
     F: AsRef<str>,


### PR DESCRIPTION
The lifetimes were redundant due to Rust's lifetime elision rules. Simplified the function signatures for better readability.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
